### PR TITLE
chore(package): use absolute path for files

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "pretest": "npm run build"
   },
   "files": [
-    "dist"
+    "/dist"
   ]
 }


### PR DESCRIPTION
Avoid matching subfolders with the same name (in case this happens)

>Note that you want to prefix all the elements of files with “/”. Otherwise, if you had a directory “test/lib” that would be included as well. Not really a security concern generally, but it helps keep things clean.

[link](https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d)