### PR TITLE
Add an npmrc.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry = "https://registry.npmjs.com/"


### PR DESCRIPTION
This is largely unnecessary, unless you're on a computer that has a global registry value configured for something else. This is common in corporate networks.