### PR TITLE
Require Node.js 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
+  - '12'
   - '11'
   - '10'
-  - '8'
-  - '6'


### PR DESCRIPTION
Drop support of Node.js 6 and 8.

Following the Breaking Changes introduced in the Rollup v2.0.0, I'm proposing
to update the `.travis.yml` configuration to be aligned wit the Node.js versions
supported.

**Breaking Changes**:
- Rollup now requires at least Node 10 to run(…)

Source: https://github.com/rollup/rollup/releases/tag/v2.0.0

Regarding how `.travis.yml` can be configured, I decided to list all supported
versions instead of using `lts/*`.

Sources:
- https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions
- https://nodejs.org/en/about/releases/

This Pull Request can be merged right after #62.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>