### PR TITLE
bump node-resolve to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.1",
-    "@rollup/plugin-node-resolve": "^7.0.0",
+    "@rollup/plugin-node-resolve": "^9.0.0",
     "rollup": "^1.29.0"
   },
   "scripts": {


### PR DESCRIPTION
Bump node-resolve to latest

(Sorry, should have included this in https://github.com/rollup/rollup-starter-lib/pull/71) 